### PR TITLE
Adds OAuth2-proxy for authentication

### DIFF
--- a/infrastructure/production/kustomization.yaml
+++ b/infrastructure/production/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
 - metallb
 - nfs-provisioner
 - external-secrets
+- oauth2-proxy
 #- redpanda

--- a/infrastructure/production/oauth2proxy/kustomization.yaml
+++ b/infrastructure/production/oauth2proxy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: oauth2-proxy
+resources:
+  - namespace.yaml
+  - release.yaml
+  - secrets.yaml

--- a/infrastructure/production/oauth2proxy/namespace.yaml
+++ b/infrastructure/production/oauth2proxy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oauth2-proxy

--- a/infrastructure/production/oauth2proxy/release.yaml
+++ b/infrastructure/production/oauth2proxy/release.yaml
@@ -1,0 +1,50 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  releaseName: oauth2-proxy
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: external-secrets
+      namespace: flux-system
+  chart:
+    spec:
+      chart: oauth2-proxy
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+        namespace: flux-system
+      version: "7.0.0"
+  valuesFrom:
+    - kind: Secret
+      name: oauth2-proxy-secrets
+      valuesKey: client-id
+      targetPath: extraArgs.client-id
+    - kind: Secret
+      name: oauth2-proxy-secrets
+      valuesKey: client-secret
+      targetPath: extraArgs.client-secret
+    - kind: Secret
+      name: oauth2-proxy-secrets
+      valuesKey: cookie-secret
+      targetPath: extraArgs.cookie-secret
+  values:
+    extraArgs:
+      provider: "google"
+      oidc-issuer-url: "https://accounts.google.com"
+      cookie-domain: ".patrick-evers.nl"
+      set-authorization-header: true
+      skip-provider-button: true
+      email-domain: "patrick-evers.nl"
+      redirect-url: "https://identity.patrick-evers.nl/oauth2/callback"
+    ingress:
+      enabled: true
+      className: nginx
+      hosts:
+        - identity.patrick-evers.nl
+      annotations:
+        nginx.ingress.kubernetes.io/auth-url: "https://identity.patrick-evers.nl/oauth2/auth"
+        nginx.ingress.kubernetes.io/auth-signin: "https://identity.patrick-evers.nl/oauth2/start?rd=$request_uri"

--- a/infrastructure/production/oauth2proxy/secrets.yaml
+++ b/infrastructure/production/oauth2proxy/secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: oauth2-proxy-secrets
+  namespace: oauth2-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: vault-backend
+  target:
+    name: oauth2-proxy-secrets
+    namespace: oauth2-proxy
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: oauth2-proxy/google/client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: oauth2-proxy/google/client-secret
+    - secretKey: cookie-secret
+      remoteRef:
+        key: oauth2-proxy/cookie-secret

--- a/infrastructure/production/sources/kustomization.yaml
+++ b/infrastructure/production/sources/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - nfs-subdir.yaml
   - external-secrets.yaml
   - redpanda.yaml
+  - oauth2-proxy.yaml

--- a/infrastructure/production/sources/oauth2-proxy.yaml
+++ b/infrastructure/production/sources/oauth2-proxy.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+spec:
+  interval: 30m
+  url: https://oauth2-proxy.github.io/manifests


### PR DESCRIPTION
Implements OAuth2-proxy to provide authentication for services.

- Includes namespace, HelmRelease, and ExternalSecret configurations.
- Configures OAuth2-proxy to use Google as an OIDC provider.
- Adds a HelmRepository source for the OAuth2-proxy chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OAuth2 Proxy deployment for authentication in the production environment.
  * Added a dedicated namespace and secret management for OAuth2 Proxy.
  * Enabled integration with Google as the identity provider and restricted access by email domain.
  * Configured secure secret synchronization from an external vault.
  * Set up ingress for OAuth2 Proxy with authentication endpoints for protected access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->