### PR TITLE
Enables Redpanda deployment in production

### DIFF
--- a/infrastructure/production/kustomization.yaml
+++ b/infrastructure/production/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 - nfs-provisioner
 - external-secrets
 #- onepassword-connect
-#- redpanda
+- redpanda

--- a/infrastructure/production/redpanda/release.yaml
+++ b/infrastructure/production/redpanda/release.yaml
@@ -20,8 +20,3 @@ spec:
   values:
     statefulset:
       replicas: 1
-      initContainers:
-        setDataDirOwnership:
-          enabled: true
-    tuning:
-      tune_aio_events: false


### PR DESCRIPTION
Enables Redpanda to be deployed within the production environment.

- Configures the deployment by adding it to the kustomization file.
- Removes unnecessary tuning configurations from the Redpanda Helm chart values.